### PR TITLE
Work around for pylint no-value-for-parameter

### DIFF
--- a/src/h_matchers/matcher/collection/_mixin/contains.py
+++ b/src/h_matchers/matcher/collection/_mixin/contains.py
@@ -16,7 +16,12 @@ class ContainsMixin:
     _in_order = False
     _exact_match = False
 
+    @staticmethod
+    def containing(items):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
     @fluent_entrypoint
+    # pylint: disable=function-redefined
     def containing(self, items):
         """Specify that this item must contain these items.
 

--- a/src/h_matchers/matcher/collection/_mixin/item_matcher.py
+++ b/src/h_matchers/matcher/collection/_mixin/item_matcher.py
@@ -11,7 +11,12 @@ class ItemMatcherMixin:
 
     _item_matcher = None
 
+    @staticmethod
+    def comprised_of(item_type):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
     @fluent_entrypoint
+    # pylint: disable=function-redefined
     def comprised_of(self, item_type):
         """Specify that every item in the iterable should match a single type.
 

--- a/src/h_matchers/matcher/collection/_mixin/size.py
+++ b/src/h_matchers/matcher/collection/_mixin/size.py
@@ -12,7 +12,12 @@ class SizeMixin:
     _min_size = None
     _max_size = None
 
+    @staticmethod
+    def of_size(exact=None, at_least=None, at_most=None):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
     @fluent_entrypoint
+    # pylint: disable=function-redefined
     def of_size(self, exact=None, at_least=None, at_most=None):
         """Limit the size of the list.
 

--- a/src/h_matchers/matcher/collection/_mixin/type.py
+++ b/src/h_matchers/matcher/collection/_mixin/type.py
@@ -11,7 +11,12 @@ class TypeMixin:
 
     _exact_type = None
 
+    @staticmethod
+    def of_type(of_type):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
     @fluent_entrypoint
+    # pylint: disable=function-redefined
     def of_type(self, of_type):
         """Limit the type to a specific type like `list` or `set`.
 

--- a/tests/unit/h_matchers/matcher/collection/_mixin/contains_test.py
+++ b/tests/unit/h_matchers/matcher/collection/_mixin/contains_test.py
@@ -1,5 +1,3 @@
-# pylint: disable=no-value-for-parameter
-
 import pytest
 
 from h_matchers.exception import NoMatch

--- a/tests/unit/h_matchers/matcher/collection/_mixin/item_matcher_test.py
+++ b/tests/unit/h_matchers/matcher/collection/_mixin/item_matcher_test.py
@@ -2,8 +2,6 @@ from h_matchers import Any
 from h_matchers.exception import NoMatch
 from h_matchers.matcher.collection._mixin.item_matcher import ItemMatcherMixin
 
-# pylint: disable=no-value-for-parameter
-
 
 class HostClass(ItemMatcherMixin):
     def __eq__(self, other):

--- a/tests/unit/h_matchers/matcher/collection/_mixin/size_test.py
+++ b/tests/unit/h_matchers/matcher/collection/_mixin/size_test.py
@@ -3,8 +3,6 @@ import pytest
 from h_matchers.exception import NoMatch
 from h_matchers.matcher.collection._mixin.size import SizeMixin
 
-# pylint: disable=no-value-for-parameter
-
 
 class HostClass(SizeMixin):
     def __eq__(self, other):

--- a/tests/unit/h_matchers/matcher/collection/_mixin/type_test.py
+++ b/tests/unit/h_matchers/matcher/collection/_mixin/type_test.py
@@ -1,8 +1,6 @@
 from h_matchers.exception import NoMatch
 from h_matchers.matcher.collection._mixin.type import TypeMixin
 
-# pylint: disable=no-value-for-parameter
-
 
 class HostClass(TypeMixin):
     def __eq__(self, other):


### PR DESCRIPTION
When using h-matchers pylint flags our fluent end-points as having
unfilled parameters. It's wrong, but it's not good to force consumers to
disable this message.

This work around appears to disable it. It's not good, but it's better than
disabling the pylint warning in all consuming code.