### PR TITLE
Prevent paths from matching anywhere in the string

### DIFF
--- a/src/h_matchers/matcher/web/url/core.py
+++ b/src/h_matchers/matcher/web/url/core.py
@@ -182,7 +182,7 @@ class AnyURLCore(Matcher):
         # Otherwise construct a matcher which doesn't care about leading
         # slashes
 
-        return AnyStringMatching(f"/?{re.escape(path)}")
+        return AnyStringMatching(f"^/?{re.escape(path)}$")
 
     def _set_query(self, query, exact_match=True):
         if query is not self.APPLY_DEFAULT:

--- a/tests/unit/h_matchers/matcher/web/url/core_test.py
+++ b/tests/unit/h_matchers/matcher/web/url/core_test.py
@@ -204,6 +204,9 @@ class TestAnyURLPathMatching:
         assert "path" != matcher
         assert "/path" == matcher
 
+    def test_it_does_not_match_prefixes_alone(self):
+        assert AnyURLCore(path="/start") != "http://example.com/start/more"
+
 
 class TestAnyURLHostnameGuessing:
     @pytest.mark.parametrize(


### PR DESCRIPTION
The regex was unanchored and applied with 'search' not 'match'

Without this patch the following would match:

    Any.url(path='foo') == 'http://example.com/foooooooooooo'