### PR TITLE
Users cannot specify an Any matcher with the fluent matcher

### DIFF
--- a/src/h_matchers/matcher/web/url/fluent.py
+++ b/src/h_matchers/matcher/web/url/fluent.py
@@ -19,7 +19,7 @@ class AnyURL(AnyURLCore):
     }
 
     def _apply_field_default(self, field, value):
-        if value != AnyURLCore.APPLY_DEFAULT:
+        if value is not AnyURLCore.APPLY_DEFAULT:
             return value
 
         return self.PRESENT_DEFAULT[field]

--- a/tests/unit/h_matchers/matcher/web/url/fluent_test.py
+++ b/tests/unit/h_matchers/matcher/web/url/fluent_test.py
@@ -1,3 +1,6 @@
+import pytest
+
+from h_matchers.matcher.anything import AnyThing
 from h_matchers.matcher.web.url.fluent import AnyURL
 
 # pylint: disable=compare-to-empty-string
@@ -88,6 +91,23 @@ class TestAnyURLFluent:
         assert matcher == "http://example.com#fragment"
         assert matcher != "#different"
         assert matcher != "http://example.com"
+
+    @pytest.mark.parametrize(
+        "method,part",
+        (
+            (AnyURL.with_scheme, "scheme"),
+            (AnyURL.with_host, "host"),
+            (AnyURL.with_path, "path"),
+            (AnyURL.with_query, "query"),
+            (AnyURL.containing_query, "query"),
+            (AnyURL.with_fragment, "fragment"),
+        ),
+    )
+    def test_we_can_set_any_matcher(self, method, part):
+        any_matcher = AnyThing()
+        matcher = method(any_matcher)
+
+        assert matcher.parts[part] is any_matcher
 
     def test_all_methods_together(self):
         base_url = "http://example.com/path?a=b#fragment"


### PR DESCRIPTION
If a matcher "matches" the default sentinel, we apply the default, not the matcher.