### PR TITLE
Stop guessing host based on port

### DIFF
--- a/src/h_matchers/matcher/web/url/core.py
+++ b/src/h_matchers/matcher/web/url/core.py
@@ -214,15 +214,10 @@ class AnyURLCore(Matcher):
             if values[key] is default_key:
                 values[key] = default_value
 
-    PORT_PATTERN = re.compile(r".*:\d{2,5}$")
-
     @classmethod
     def _is_hostname(cls, host):
         if not host:
             return False
-
-        if cls.PORT_PATTERN.match(host):
-            return True
 
         if "." in host:
             return True

--- a/tests/unit/h_matchers/matcher/web/url/core_test.py
+++ b/tests/unit/h_matchers/matcher/web/url/core_test.py
@@ -224,13 +224,16 @@ class TestAnyURLHostnameGuessing:
             ("127.0.0.1/path", "127.0.0.1", "/path"),
             # Indicators of bare hostnames should be respected
             ("localhost", "localhost", None),
-            ("localhost:9000", "localhost:9000", None),
             ("example.com", "example.com", None),
             # A scheme tells us the next part is a host
             ("http://example.com/", "example.com", "/"),
             ("http://path", "path", None),
             ("http:///path", None, "/path"),
             ("http://?a=b", None, None),
+            # Skip
+            # These get interpreted inconsistently as scheme / path
+            # ("localhost:9000", "localhost:9000", None),
+            # ("localhost:9000/path", "localhost:9000", "/path"),
         ),
     )
     def test_hostname_guessing(self, url, expected_host, expected_path):


### PR DESCRIPTION
 * If there is a slash urllib things the port is the path
 * If there's not it things the whole thing is the path
 * There isn't a nice way to deal with this as it stands
 * Better to not try for the moment