### PR TITLE
Fix `Any.instance_of` acting as a singleton

### DIFF
--- a/src/h_matchers/decorator.py
+++ b/src/h_matchers/decorator.py
@@ -10,8 +10,6 @@ class fluent_entrypoint:  # pylint: disable=invalid-name,too-few-public-methods
     that you class not accept any arguments for instantiation.
     """
 
-    instance = None
-
     def __init__(self, function):
         self.function = function
 

--- a/src/h_matchers/interface.py
+++ b/src/h_matchers/interface.py
@@ -31,7 +31,6 @@ class Any(AnyThing):
 
     function = AnyFunction
     callable = AnyCallable
-    instance_of = AnyObject.of_type
 
     iterable = AnyCollection
     mapping = AnyMapping
@@ -42,6 +41,14 @@ class Any(AnyThing):
     url = AnyURL
 
     of = AnyOf
+
+    @staticmethod
+    def instance_of(type_):
+        """Specify that this item must be an instance of the provided type.
+
+        :return: An instance of AnyObject configured with the given type.
+        """
+        return AnyObject.of_type(type_)
 
 
 class All(AllOf):

--- a/src/h_matchers/matcher/collection/_mixin/size.py
+++ b/src/h_matchers/matcher/collection/_mixin/size.py
@@ -45,6 +45,7 @@ class SizeMixin:
 
         return self
 
+    # pylint: disable=unused-argument
     def _check_size(self, other, original=None):
         """Run the size check (if any)."""
         if self._min_size and len(other) < self._min_size:

--- a/tests/unit/h_matchers/interface_test.py
+++ b/tests/unit/h_matchers/interface_test.py
@@ -30,6 +30,14 @@ class TestAny:
     def test_is_subclass_of_AnyThing(self):
         assert issubclass(Any, AnyThing)
 
+    def test_instance_of_is_not_singleton(self):
+        # This is a regression test to ensure we don't have singleton like
+        # behavior from Any.instance_of
+        matcher = Any.instance_of(int)
+        Any.instance_of(str)
+
+        assert matcher == 1
+
 
 class TestAll:
     def test_it_has_expected_attributes(self):


### PR DESCRIPTION
Previously running doing:

```
matcher_1 = Any.instance_of(int)
matcher_2 = Any.instance_of(str)
```

Would result in `matcher_1` becoming a string matcher.

This is a result of assigning the `type_of` method. This causes it's `__get__` to be accessed when it is retrieved from the parent object. The `fluent_entrypoint` triggers at this time and creates an instance, which is assigned. At least that's my theory. Doesn't matter too much as it's easy to prevent.

Also fixed some random lint spam.