### PR TITLE
Fix isort (make format and make checkformatting)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pip install black isort
         black --check src tests bin
-        isort --recursive --quiet --check-only .
+        isort --quiet --check-only .
 
     # Dependencies are checked by pylint,
     # so this is as late as we can leave this

--- a/.pylintrc
+++ b/.pylintrc
@@ -14,6 +14,7 @@ load-plugins=pylint.extensions.bad_builtin,
 disable=bad-continuation,
         missing-type-doc,
         missing-return-type-doc,
+        wrong-import-order,
 
 [REPORTS]
 output-format=colorized

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -21,6 +21,7 @@ disable=bad-continuation,
         no-self-use,
         redefined-outer-name,
         too-few-public-methods,
+        wrong-import-order,
 
 [REPORTS]
 output-format=colorized

--- a/tests/unit/h_matchers/matcher/anything_test.py
+++ b/tests/unit/h_matchers/matcher/anything_test.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.unit.data_types import DataTypes
 
 from h_matchers.matcher.anything import AnyThing
+from tests.unit.data_types import DataTypes
 
 
 class TestAnything:

--- a/tests/unit/h_matchers/matcher/collection/containment_test.py
+++ b/tests/unit/h_matchers/matcher/collection/containment_test.py
@@ -1,6 +1,5 @@
 # pylint: disable=misplaced-comparison-constant
 import pytest
-from tests.unit.data_types import DataTypes
 
 from h_matchers import Any
 from h_matchers.matcher.collection.containment import (
@@ -8,6 +7,7 @@ from h_matchers.matcher.collection.containment import (
     AnyIterableWithItemsInOrder,
     AnyMappingWithItems,
 )
+from tests.unit.data_types import DataTypes
 
 
 class MultiDict(list):

--- a/tests/unit/h_matchers/matcher/collection_test.py
+++ b/tests/unit/h_matchers/matcher/collection_test.py
@@ -1,11 +1,11 @@
 from unittest.mock import Mock, create_autospec
 
 import pytest
-from tests.unit.data_types import DataTypes
 
 from h_matchers import Any
 from h_matchers.exception import NoMatch
 from h_matchers.matcher.collection import AnyCollection, AnyMapping
+from tests.unit.data_types import DataTypes
 
 
 class TestAnyCollection:

--- a/tests/unit/h_matchers/matcher/meta_test.py
+++ b/tests/unit/h_matchers/matcher/meta_test.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.unit.data_types import DataTypes
 
 from h_matchers.matcher.meta import AnyCallable, AnyFunction
+from tests.unit.data_types import DataTypes
 
 
 class TestAnyFunction:

--- a/tests/unit/h_matchers/matcher/number_test.py
+++ b/tests/unit/h_matchers/matcher/number_test.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.unit.data_types import DataTypes
 
 from h_matchers.matcher.number import AnyInt
+from tests.unit.data_types import DataTypes
 
 
 class TestAnyInt:

--- a/tests/unit/h_matchers/matcher/strings_test.py
+++ b/tests/unit/h_matchers/matcher/strings_test.py
@@ -1,9 +1,9 @@
 import re
 
 import pytest
-from tests.unit.data_types import DataTypes
 
 from h_matchers.matcher.strings import AnyString, AnyStringContaining, AnyStringMatching
+from tests.unit.data_types import DataTypes
 
 
 class TestAnyString:

--- a/tox.ini
+++ b/tox.ini
@@ -43,10 +43,10 @@ commands =
     lint: pylint --rcfile=tests/.pylintrc tests
 
     format: black {posargs:src tests bin}
-    format: isort --recursive --atomic .
+    format: isort --atomic .
 
     checkformatting: black --check {posargs:src tests bin}
-    checkformatting: isort --recursive --quiet --check-only .
+    checkformatting: isort --quiet --check-only .
 
     coverage: -coverage combine
     coverage: coverage report


### PR DESCRIPTION
isort 5.0 removed the `--recursive` option, it's now just always
recursive:

https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020