### PR TITLE
Add a request matcher that can match various different request objects

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 filterwarnings =
     # Fail the tests if there are any warnings.
     error
+
+    # Silence an imp warning that pyramid path causes
+    ignore:^the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses$:DeprecationWarning:.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,4 +27,6 @@ install_requires =
 tests_require=
     pytest
     coverage
-
+    # For requests matching
+    requests
+    pyramid

--- a/src/h_matchers/decorator.py
+++ b/src/h_matchers/decorator.py
@@ -8,6 +8,8 @@ class fluent_entrypoint:  # pylint: disable=invalid-name,too-few-public-methods
     If the wrapped method is called as a classmethod an instance will first
     be created and then passed to the object. It is therefore important
     that you class not accept any arguments for instantiation.
+
+    This will automatically return `self` for fluent chaining in your methods.
     """
 
     def __init__(self, function):
@@ -20,6 +22,8 @@ class fluent_entrypoint:  # pylint: disable=invalid-name,too-few-public-methods
             obj = _type()
 
         def wrapper(*args, **kwargs):
-            return self.function(obj, *args, **kwargs)
+            self.function(obj, *args, **kwargs)
+
+            return obj
 
         return wrapper

--- a/src/h_matchers/matcher/collection/_mixin/contains.py
+++ b/src/h_matchers/matcher/collection/_mixin/contains.py
@@ -38,7 +38,6 @@ class ContainsMixin:
 
         :param items: A set or list of items to check for
         :raises ValueError: If you provide something other than a set or list
-        :return: self - for fluent chaining
         """
 
         if isinstance(items, ContainsMixin):
@@ -47,8 +46,6 @@ class ContainsMixin:
             items = items._items
 
         self._items = items
-
-        return self
 
     def in_order(self):
         """Set that matched items can occur in any order.

--- a/src/h_matchers/matcher/collection/_mixin/contains.py
+++ b/src/h_matchers/matcher/collection/_mixin/contains.py
@@ -41,6 +41,11 @@ class ContainsMixin:
         :return: self - for fluent chaining
         """
 
+        if isinstance(items, ContainsMixin):
+            # It's ok, because it's our class
+            # pylint: disable=protected-access
+            items = items._items
+
         self._items = items
 
         return self

--- a/src/h_matchers/matcher/collection/_mixin/item_matcher.py
+++ b/src/h_matchers/matcher/collection/_mixin/item_matcher.py
@@ -26,11 +26,9 @@ class ItemMatcherMixin:
         Can be called as an instance or class method.
 
         :param item_type: The type to match again (can be another matcher)
-        :return: self - for fluent chaining
         """
 
         self._item_matcher = item_type
-        return self
 
     def _check_item_matcher(self, other, original):
         """Check to see if all items in the object match a pattern."""

--- a/src/h_matchers/matcher/collection/_mixin/size.py
+++ b/src/h_matchers/matcher/collection/_mixin/size.py
@@ -27,7 +27,6 @@ class SizeMixin:
         :param at_least: Specify a minimum size
         :param at_most: Specify a maximum size
         :raises ValueError: If arguments are missing or incompatible
-        :return: self - for fluent chaining
         """
         if exact is not None:
             self._min_size = exact
@@ -42,8 +41,6 @@ class SizeMixin:
 
             self._min_size = at_least
             self._max_size = at_most
-
-        return self
 
     # pylint: disable=unused-argument
     def _check_size(self, other, original=None):

--- a/src/h_matchers/matcher/collection/_mixin/type.py
+++ b/src/h_matchers/matcher/collection/_mixin/type.py
@@ -21,12 +21,8 @@ class TypeMixin:
         """Limit the type to a specific type like `list` or `set`.
 
         Can be called as an instance or class method.
-
-        :return: self - for fluent chaining
         """
         self._exact_type = of_type
-
-        return self
 
     def _check_type(self, _, original):
         if self._exact_type:

--- a/src/h_matchers/matcher/collection/containment.py
+++ b/src/h_matchers/matcher/collection/containment.py
@@ -158,7 +158,8 @@ class AnyMappingWithItems(Matcher):
             if key not in container:
                 return False
 
-            if container[key] != value:
+            # Do the comparison backwards to give matchers a chance to kick in
+            if value != container[key]:
                 return False
 
         return True

--- a/src/h_matchers/matcher/object.py
+++ b/src/h_matchers/matcher/object.py
@@ -46,11 +46,8 @@ class AnyObject(Matcher):  # pragma: no cover
         Can be called as an instance or class method.
 
         :param type_: The type this object will match
-        :return: self - for fluent chaining
         """
         self.__type = type_
-
-        return self
 
     @staticmethod
     def with_attrs(attributes):
@@ -69,15 +66,12 @@ class AnyObject(Matcher):  # pragma: no cover
         Can be called as an instance or class method.
 
         :param attributes: A mapping of attributes to values
-        :return: self - for fluent chaining
         :raise ValueError: If the provided attributes do not support `items()`
         """
         if not hasattr(attributes, "items"):
             raise ValueError("The attributes must be a mapping")
 
         self.__attributes = attributes
-
-        return self
 
     def _matches_object(self, other):
         if self.__type is not None and not isinstance(other, self.__type):

--- a/src/h_matchers/matcher/web/request.py
+++ b/src/h_matchers/matcher/web/request.py
@@ -40,29 +40,26 @@ except ImportError:  # pragma: no cover
 class AnyRequest(Matcher):  # pragma: no cover
     """Matching object for request type objects.
 
-    For a particular request type to be comparable it must be supported and you
-    must have installed it as a requirement. Requests libraries are not added
-    as dependencies of this package to prevent them from bloating your project.
-
-    If a dependency is not installed we will simply fail to match against it.
-
     Currently supported request objects:
 
+     * `requests.Request`
      * `requests.PreparedRequest`
+     * `pyramid.request.Request`
+     * `pyramid.testing.Request`
     """
+
+    # Use a set here as an optimisation for when many of these items are
+    # instances of `_LibraryNotAvailable`
+    SUPPORTED_TYPES = tuple(
+        {RequestsRequest, RequestsPreparedRequest, PyramidRequest, PyramidDummyRequest}
+    )
 
     # Enable failing on comparison instead of returning False. This can be very
     # useful for debugging as we can fail fast and return a message about why
     # we can't match. We might want to think about making this a more general
     # feature. It would be very handy for the more complex matchers
-    SUPPORTED_TYPES = (
-        RequestsRequest,
-        RequestsPreparedRequest,
-        PyramidRequest,
-        PyramidDummyRequest,
-    )
-
     _assert_on_comparison = False
+
     method = None
     url = None
     headers = None

--- a/src/h_matchers/matcher/web/request.py
+++ b/src/h_matchers/matcher/web/request.py
@@ -92,11 +92,8 @@ class AnyRequest(Matcher):  # pragma: no cover
         """Specify the request must have at least the headers specified.
 
         :param headers: A mappable of headers to match
-        :return: self for fluent chaining
         """
         self.headers = AnyMapping.containing(headers)
-
-        return self
 
     @fluent_entrypoint
     def with_headers(self, headers=...):
@@ -106,7 +103,6 @@ class AnyRequest(Matcher):  # pragma: no cover
         libraries add it before sending, and it's mostly noise.
 
         :param headers: A mappable of headers or matcher to match exactly
-        :return: self for fluent chaining
         """
         if headers is ...:
             self.headers = AnyMapping.of_size(at_least=1)
@@ -117,14 +113,11 @@ class AnyRequest(Matcher):  # pragma: no cover
         elif headers is not None:
             self.headers = AnyMapping.containing(headers).only()
 
-        return self
-
     @fluent_entrypoint
     def with_method(self, method=...):
         """Specify the request must have a method.
 
         :param method: A string or matcher for the method
-        :return: self for fluent chaining
         """
         if method is ...:
             self.method = AnyString()
@@ -135,14 +128,11 @@ class AnyRequest(Matcher):  # pragma: no cover
         elif method is not None:
             self.method = method
 
-        return self
-
     @fluent_entrypoint
     def with_url(self, url=...):
         """Specify the request must have a URL.
 
         :param url: A string or matcher for the URL
-        :return: self for fluent chaining
         """
         if url is ...:
             self.url = AnyURL()
@@ -152,8 +142,6 @@ class AnyRequest(Matcher):  # pragma: no cover
 
         elif url is not None:
             self.url = url
-
-        return self
 
     def assert_equal_to(self, other):
         """Assert that the request object is equal to another object.

--- a/src/h_matchers/matcher/web/request.py
+++ b/src/h_matchers/matcher/web/request.py
@@ -1,0 +1,214 @@
+"""A matcher that matches various request objects in HTTP type libraries."""
+from copy import deepcopy
+
+from h_matchers.decorator import fluent_entrypoint
+from h_matchers.matcher.collection import AnyMapping
+from h_matchers.matcher.core import Matcher
+from h_matchers.matcher.strings import AnyString
+from h_matchers.matcher.web.url import AnyURL
+
+# pylint: disable=too-few-public-methods
+
+
+class _LibraryNotAvailable:
+    """Substitute for missing libraries."""
+
+
+try:  # pylint: disable=too-many-try-statements
+    # We don't require our clients to install every request library we support
+    # so we will enable it if it's around, and carry on without if it's not
+    from requests import PreparedRequest as RequestsPreparedRequest
+    from requests import Request as RequestsRequest
+
+except ImportError:  # pragma: no cover
+    RequestsRequest, RequestsPreparedRequest = (
+        _LibraryNotAvailable,
+        _LibraryNotAvailable,
+    )
+
+try:  # pylint: disable=too-many-try-statements
+    from pyramid.request import Request as PyramidRequest
+    from pyramid.testing import DummyRequest as PyramidDummyRequest
+
+except ImportError:  # pragma: no cover
+    PyramidDummyRequest, PyramidRequest = _LibraryNotAvailable, _LibraryNotAvailable
+
+
+# pylint: disable=function-redefined
+
+
+class AnyRequest(Matcher):  # pragma: no cover
+    """Matching object for request type objects.
+
+    For a particular request type to be comparable it must be supported and you
+    must have installed it as a requirement. Requests libraries are not added
+    as dependencies of this package to prevent them from bloating your project.
+
+    If a dependency is not installed we will simply fail to match against it.
+
+    Currently supported request objects:
+
+     * `requests.PreparedRequest`
+    """
+
+    # Enable failing on comparison instead of returning False. This can be very
+    # useful for debugging as we can fail fast and return a message about why
+    # we can't match. We might want to think about making this a more general
+    # feature. It would be very handy for the more complex matchers
+    SUPPORTED_TYPES = (
+        RequestsRequest,
+        RequestsPreparedRequest,
+        PyramidRequest,
+        PyramidDummyRequest,
+    )
+
+    _assert_on_comparison = False
+    method = None
+    url = None
+    headers = None
+
+    def __init__(self, method=..., url=..., headers=None):
+        self.with_method(method)
+        self.with_url(url)
+        self.with_headers(headers)
+
+        super().__init__("*dummy*", self._matches_request)
+
+    @classmethod
+    def containing_headers(cls, headers):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
+    @classmethod
+    def with_headers(cls, header=...):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
+    @classmethod
+    def with_method(cls, method=...):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
+    @classmethod
+    def with_url(cls, url=...):
+        """Confuse pylint so it doesn't complain about fluent-endpoints."""
+
+    @fluent_entrypoint
+    def containing_headers(self, headers):
+        """Specify the request must have at least the headers specified.
+
+        :param headers: A mappable of headers to match
+        :return: self for fluent chaining
+        """
+        self.headers = AnyMapping.containing(headers)
+
+        return self
+
+    @fluent_entrypoint
+    def with_headers(self, headers=...):
+        """Specify the request must have headers.
+
+        This method will remove 'Host' from the set of headers as some
+        libraries add it before sending, and it's mostly noise.
+
+        :param headers: A mappable of headers or matcher to match exactly
+        :return: self for fluent chaining
+        """
+        if headers is ...:
+            self.headers = AnyMapping.of_size(at_least=1)
+
+        elif isinstance(headers, Matcher):
+            self.headers = headers
+
+        elif headers is not None:
+            self.headers = AnyMapping.containing(headers).only()
+
+        return self
+
+    @fluent_entrypoint
+    def with_method(self, method=...):
+        """Specify the request must have a method.
+
+        :param method: A string or matcher for the method
+        :return: self for fluent chaining
+        """
+        if method is ...:
+            self.method = AnyString()
+
+        elif isinstance(method, str):
+            self.method = method.upper()
+
+        elif method is not None:
+            self.method = method
+
+        return self
+
+    @fluent_entrypoint
+    def with_url(self, url=...):
+        """Specify the request must have a URL.
+
+        :param url: A string or matcher for the URL
+        :return: self for fluent chaining
+        """
+        if url is ...:
+            self.url = AnyURL()
+
+        elif isinstance(url, str):
+            self.url = AnyURL.matching(url)
+
+        elif url is not None:
+            self.url = url
+
+        return self
+
+    def assert_equal_to(self, other):
+        """Assert that the request object is equal to another object.
+
+        :raise AssertionError: If no match is found with details of why
+        """
+        if not isinstance(other, self.SUPPORTED_TYPES):
+            raise AssertionError(
+                f"Unknown request type '{type(other)}'. For a request type to be "
+                "compared it must be supported and loaded."
+            )
+
+        if self.method is not None and self.method != other.method.upper():
+            raise AssertionError(f"Method '{other.method}' != '{self.method}'")
+
+        if self.url is not None and self.url != other.url:
+            raise AssertionError(f"URL '{other.url}' != '{self.url}'")
+
+        if self.headers is not None:
+            other_headers = self._comparison_headers(other)
+            if self.headers != other_headers:
+                raise AssertionError(f"Headers {other_headers} != {self.headers}")
+
+    @classmethod
+    def _comparison_headers(cls, other):
+        if isinstance(other, PyramidRequest):
+            headers = deepcopy(other.headers)
+            headers.pop("Host")
+
+            return headers
+
+        return other.headers
+
+    def _matches_request(self, other):
+        try:
+            self.assert_equal_to(other)
+        except AssertionError:
+            if self._assert_on_comparison:
+                raise
+            return False
+
+        return True
+
+    def __str__(self):
+        details = ""
+        if self.method:
+            details += f" method:{self.method}"
+
+        if self.url:
+            details += f" url:{self.url}"
+
+        if self.headers is not None:
+            details += f" headers={self.headers}"
+
+        return f"<{self.__class__.__name__}{details}>"

--- a/src/h_matchers/matcher/web/url/fluent.py
+++ b/src/h_matchers/matcher/web/url/fluent.py
@@ -64,12 +64,9 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no scheme.
 
         :param scheme: None, string or matcher for the scheme
-        :return: self for fluent chaining
         """
 
         self.parts["scheme"] = self._apply_field_default("scheme", scheme)
-
-        return self
 
     @fluent_entrypoint
     def with_host(self, host=AnyURLCore.APPLY_DEFAULT):
@@ -78,11 +75,8 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no host.
 
         :param host: None, string or matcher for the host
-        :return: self for fluent chaining
         """
         self.parts["host"] = self._apply_field_default("host", host)
-
-        return self
 
     @fluent_entrypoint
     def with_path(self, path=AnyURLCore.APPLY_DEFAULT):
@@ -91,7 +85,6 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no path.
 
         :param path: None, string or matcher for the path
-        :return: self for fluent chaining
         """
         if path is AnyURLCore.APPLY_DEFAULT:
             self.parts["path"] = AnyString()
@@ -100,18 +93,13 @@ class AnyURL(AnyURLCore):
                 path, self.parts["scheme"], self.parts["host"]
             )
 
-        return self
-
     @fluent_entrypoint
     def containing_query(self, query):
         """Specify that the query must have at least the items specified.
 
         :param query: A mappable to check
-        :return: self for fluent chaining
         """
         self._set_query(query, exact_match=False)
-
-        return self
 
     @fluent_entrypoint
     def with_query(self, query=AnyURLCore.APPLY_DEFAULT):
@@ -120,12 +108,9 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no query.
 
         :param query: None, mapping or matcher for the query
-        :return: self for fluent chaining
         """
         query = self._apply_field_default("query", query)
         self._set_query(query)
-
-        return self
 
     @fluent_entrypoint
     def with_fragment(self, fragment=AnyURLCore.APPLY_DEFAULT):
@@ -134,8 +119,5 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no fragment.
 
         :param fragment: None, string or matcher for the fragment
-        :return: self for fluent chaining
         """
         self.parts["fragment"] = self._apply_field_default("fragment", fragment)
-
-        return self

--- a/tests/unit/h_matchers/matcher/collection/_mixin/contains_test.py
+++ b/tests/unit/h_matchers/matcher/collection/_mixin/contains_test.py
@@ -20,6 +20,14 @@ class TestContainsMixin:
         with pytest.raises(ValueError):
             HostClass().in_order()
 
+    def test_it_extracts_items_from_other_ContainsMixin_children(self):
+        doner = HostClass.containing(["a", "b", "c"])
+
+        recipient = HostClass.containing(doner)
+
+        # pylint: disable=protected-access
+        assert recipient._items == doner._items
+
     # Test delegation to matchers ------------------------------------------ #
 
     def test_it_delegates_to_AnyMappingWithItems_for_dicts(self, AnyMappingWithItems):

--- a/tests/unit/h_matchers/matcher/web/request_test.py
+++ b/tests/unit/h_matchers/matcher/web/request_test.py
@@ -1,0 +1,187 @@
+from urllib.parse import urlparse
+
+import pytest
+from pyramid.request import Request as PyramidRequest
+from pyramid.testing import DummyRequest
+from pytest import param
+from requests import PreparedRequest, Request
+
+from h_matchers import Any
+from h_matchers.matcher.collection import AnyMapping
+from h_matchers.matcher.web.request import AnyRequest
+
+# We have a lot of fixtures going on in this file
+# pylint: disable=too-many-arguments
+
+
+class TestAnyRequest:
+    @pytest.mark.parametrize(
+        "request_method,matcher_method,matches",
+        (
+            ("POST", None, True),
+            ("GET", None, True),
+            ("POST", "POST", True),
+            ("GET", "GET", True),
+            ("PoSt", "pOsT", True),
+            ("POST", "GET", False),
+            ("POST", Any.string(), True),
+            ("POST", Any.string.containing("OS"), True),
+            ("GET", Any.string.containing("OS"), False),
+        ),
+    )
+    def test_can_match_method(
+        self, request_method, matcher_method, matches, make_request, is_fluent
+    ):
+        request = make_request(method=request_method)
+
+        matcher = (
+            AnyRequest.with_method(matcher_method)
+            if is_fluent
+            else AnyRequest(method=matcher_method)
+        )
+
+        assert (request == matcher) is matches
+
+    @pytest.mark.parametrize(
+        "request_url,matcher_url,matches",
+        (
+            ("http://example.com/", None, True),
+            ("http://example.com/", "http://example.com", True),
+            ("http://EXAMPLE.COM", "http://example.com/", True),
+            ("http://example.com/path", "http://example.com/path", True),
+            ("http://not.example.com/", "http://example.com/", False),
+            ("http://example.com/", Any.url(host="example.com"), True),
+            ("http://not.example.com/", Any.url(host="example.com"), False),
+        ),
+    )
+    def test_can_match_url(
+        self, request_url, matcher_url, matches, make_request, is_fluent
+    ):
+        request = make_request(url=request_url)
+
+        matcher = (
+            AnyRequest.with_url(matcher_url)
+            if is_fluent
+            else AnyRequest(url=matcher_url)
+        )
+
+        assert (request == matcher) is matches
+
+    @pytest.mark.parametrize(
+        "header_matcher,matches",
+        (
+            param({"A": "a", "B": "b", "C": "c"}, False, id="Super set"),
+            param({"A": "a", "B": "b"}, True, id="Exact match"),
+            param({"A": "a"}, False, id="Sub set"),
+            param(AnyMapping(), True, id="Matcher"),
+            (None, True),
+        ),
+    )
+    def test_can_match_headers(self, make_request, header_matcher, matches, is_fluent):
+        headers = {"A": "a", "B": "b"}
+        request = make_request(headers=headers)
+
+        if is_fluent:
+            matcher = AnyRequest.with_headers(header_matcher)
+        else:
+            matcher = AnyRequest(headers=header_matcher)
+
+        assert (request == matcher) is matches
+
+    @pytest.mark.parametrize(
+        "header_matcher,matches",
+        (
+            param({"A": "a", "B": "b", "C": "c"}, False, id="Super set"),
+            param({"A": "a", "B": "b"}, True, id="Exact match"),
+            param({"A": "a"}, True, id="Sub set"),
+            param(AnyMapping(), True, id="Matcher"),
+            (None, True),
+        ),
+    )
+    def test_can_match_with_a_subset_of_headers(
+        self, make_request, header_matcher, matches
+    ):
+        headers = {"A": "a", "B": "b"}
+        request = make_request(headers=headers)
+
+        matcher = AnyRequest.containing_headers(header_matcher)
+
+        assert (request == matcher) is matches
+
+    @pytest.fixture
+    def make_request(self, request_class, default_params):
+        def make_request(**params):
+            params = dict(default_params, **params)
+
+            return RequestBuilder.build(class_=request_class, params=params)
+
+        return make_request
+
+    @pytest.fixture
+    def default_params(self):
+        return {"url": "http://example.com/", "method": "GET", "headers": {}}
+
+    @pytest.fixture(
+        params=(
+            param(Request, id="requests.Request"),
+            param(PreparedRequest, id="requests.PreparedRequest"),
+            param(PyramidRequest, id="pyramid.request.Request"),
+            param(DummyRequest, id="pyramid.testing.DummyRequest"),
+        )
+    )
+    def request_class(self, request):
+        # Note that `request` in this context is a pytest thing
+        return request.param
+
+    @pytest.fixture(params=[True, False], ids=["fluent", "init"])
+    def is_fluent(self, request):
+        return request.param
+
+
+class RequestBuilder:
+    @classmethod
+    def build(cls, class_, params):
+        # Requests objects
+        if issubclass(class_, Request):
+            return Request(**params)
+
+        if issubclass(class_, PreparedRequest):
+            return Request(**params).prepare()
+
+        # Pyramid objects
+        environ = cls._make_environ(**params)
+
+        if issubclass(class_, PyramidRequest):
+            return PyramidRequest(environ)
+
+        if issubclass(class_, DummyRequest):
+            request = DummyRequest(
+                environ, url=params["url"], headers=params["headers"]
+            )
+            request.method = params["method"]
+
+            return request
+
+        raise NotImplementedError(
+            f"Don't know how to build '{class_}'"
+        )  # pragma: no cover
+
+    @classmethod
+    def _make_environ(cls, method, url, headers):
+        # https://www.python.org/dev/peps/pep-0333/#environ-variables
+
+        url_parts = urlparse(url)
+
+        environ = {
+            "SERVER_PROTOCOL": "HTTP/1.0",
+            "wsgi.url_scheme": url_parts.scheme,
+            "REQUEST_METHOD": method,
+            "HTTP_HOST": url_parts.hostname,
+            "PATH_INFO": url_parts.path,
+            "QUERY_STRING": url_parts.query,
+        }
+
+        for key, value in headers.items():
+            environ[f"HTTP_{key.upper()}"] = value
+
+        return environ

--- a/tests/unit/h_matchers/matcher/web/url/core_test.py
+++ b/tests/unit/h_matchers/matcher/web/url/core_test.py
@@ -39,6 +39,20 @@ class TestAnyURL:
         assert self.BASE_URL == matcher
         assert url_with_part_changed == matcher
 
+    @pytest.mark.parametrize(
+        "base_url, url",
+        (
+            ("http://example.com", "http://example.com"),
+            ("http://example.com", "http://example.com/"),
+            ("http://example.com/", "http://example.com"),
+            ("http://example.com/", "http://example.com/"),
+        ),
+    )
+    def test_base_url_matches_with_or_without_path(self, base_url, url):
+        matcher = AnyURLCore(base_url=base_url)
+
+        assert matcher == url
+
     @pytest.mark.parametrize("part", ["scheme", "host", "path", "query", "fragment"])
     def test_a_wild_part_does_not_just_match_everything(self, part):
         # Create a matcher with the specified part wild i.e. `scheme=Any()`
@@ -67,9 +81,6 @@ class TestAnyURL:
         # Create a matcher with the specified part set to None
         # i.e. `scheme=None`
         matcher = AnyURLCore(**{part: None})
-
-        # Check that it made it to the internal `parts` dict
-        assert matcher.parts[part] is None
 
         # Check we match the URL with the part missing
         assert url_with_part_missing == matcher


### PR DESCRIPTION
This should work with various objects from Pyramid and requests. 

I'm not sure if we should be looking lower down the stack and handling `webob.Requests` / whatever these might be based on instead. If that worked we'd handle a wider variety of things. This meets our needs for the moment though.