### PR TITLE
Modify fluent_entrypoint to always return `self`

### DIFF
--- a/src/h_matchers/decorator.py
+++ b/src/h_matchers/decorator.py
@@ -8,6 +8,8 @@ class fluent_entrypoint:  # pylint: disable=invalid-name,too-few-public-methods
     If the wrapped method is called as a classmethod an instance will first
     be created and then passed to the object. It is therefore important
     that you class not accept any arguments for instantiation.
+
+    This will automatically return `self` for fluent chaining in your methods.
     """
 
     def __init__(self, function):
@@ -20,6 +22,8 @@ class fluent_entrypoint:  # pylint: disable=invalid-name,too-few-public-methods
             obj = _type()
 
         def wrapper(*args, **kwargs):
-            return self.function(obj, *args, **kwargs)
+            self.function(obj, *args, **kwargs)
+
+            return obj
 
         return wrapper

--- a/src/h_matchers/matcher/collection/_mixin/contains.py
+++ b/src/h_matchers/matcher/collection/_mixin/contains.py
@@ -38,7 +38,6 @@ class ContainsMixin:
 
         :param items: A set or list of items to check for
         :raises ValueError: If you provide something other than a set or list
-        :return: self - for fluent chaining
         """
 
         if isinstance(items, ContainsMixin):
@@ -47,8 +46,6 @@ class ContainsMixin:
             items = items._items
 
         self._items = items
-
-        return self
 
     def in_order(self):
         """Set that matched items can occur in any order.

--- a/src/h_matchers/matcher/collection/_mixin/item_matcher.py
+++ b/src/h_matchers/matcher/collection/_mixin/item_matcher.py
@@ -26,11 +26,9 @@ class ItemMatcherMixin:
         Can be called as an instance or class method.
 
         :param item_type: The type to match again (can be another matcher)
-        :return: self - for fluent chaining
         """
 
         self._item_matcher = item_type
-        return self
 
     def _check_item_matcher(self, other, original):
         """Check to see if all items in the object match a pattern."""

--- a/src/h_matchers/matcher/collection/_mixin/size.py
+++ b/src/h_matchers/matcher/collection/_mixin/size.py
@@ -27,7 +27,6 @@ class SizeMixin:
         :param at_least: Specify a minimum size
         :param at_most: Specify a maximum size
         :raises ValueError: If arguments are missing or incompatible
-        :return: self - for fluent chaining
         """
         if exact is not None:
             self._min_size = exact
@@ -42,8 +41,6 @@ class SizeMixin:
 
             self._min_size = at_least
             self._max_size = at_most
-
-        return self
 
     # pylint: disable=unused-argument
     def _check_size(self, other, original=None):

--- a/src/h_matchers/matcher/collection/_mixin/type.py
+++ b/src/h_matchers/matcher/collection/_mixin/type.py
@@ -21,12 +21,8 @@ class TypeMixin:
         """Limit the type to a specific type like `list` or `set`.
 
         Can be called as an instance or class method.
-
-        :return: self - for fluent chaining
         """
         self._exact_type = of_type
-
-        return self
 
     def _check_type(self, _, original):
         if self._exact_type:

--- a/src/h_matchers/matcher/object.py
+++ b/src/h_matchers/matcher/object.py
@@ -46,11 +46,8 @@ class AnyObject(Matcher):  # pragma: no cover
         Can be called as an instance or class method.
 
         :param type_: The type this object will match
-        :return: self - for fluent chaining
         """
         self.__type = type_
-
-        return self
 
     @staticmethod
     def with_attrs(attributes):
@@ -69,15 +66,12 @@ class AnyObject(Matcher):  # pragma: no cover
         Can be called as an instance or class method.
 
         :param attributes: A mapping of attributes to values
-        :return: self - for fluent chaining
         :raise ValueError: If the provided attributes do not support `items()`
         """
         if not hasattr(attributes, "items"):
             raise ValueError("The attributes must be a mapping")
 
         self.__attributes = attributes
-
-        return self
 
     def _matches_object(self, other):
         if self.__type is not None and not isinstance(other, self.__type):

--- a/src/h_matchers/matcher/web/request.py
+++ b/src/h_matchers/matcher/web/request.py
@@ -95,11 +95,8 @@ class AnyRequest(Matcher):  # pragma: no cover
         """Specify the request must have at least the headers specified.
 
         :param headers: A mappable of headers to match
-        :return: self for fluent chaining
         """
         self.headers = AnyMapping.containing(headers)
-
-        return self
 
     @fluent_entrypoint
     def with_headers(self, headers=...):
@@ -109,7 +106,6 @@ class AnyRequest(Matcher):  # pragma: no cover
         libraries add it before sending, and it's mostly noise.
 
         :param headers: A mappable of headers or matcher to match exactly
-        :return: self for fluent chaining
         """
         if headers is ...:
             self.headers = AnyMapping.of_size(at_least=1)
@@ -120,14 +116,11 @@ class AnyRequest(Matcher):  # pragma: no cover
         elif headers is not None:
             self.headers = AnyMapping.containing(headers).only()
 
-        return self
-
     @fluent_entrypoint
     def with_method(self, method=...):
         """Specify the request must have a method.
 
         :param method: A string or matcher for the method
-        :return: self for fluent chaining
         """
         if method is ...:
             self.method = AnyString()
@@ -138,14 +131,11 @@ class AnyRequest(Matcher):  # pragma: no cover
         elif method is not None:
             self.method = method
 
-        return self
-
     @fluent_entrypoint
     def with_url(self, url=...):
         """Specify the request must have a URL.
 
         :param url: A string or matcher for the URL
-        :return: self for fluent chaining
         """
         if url is ...:
             self.url = AnyURL()
@@ -155,8 +145,6 @@ class AnyRequest(Matcher):  # pragma: no cover
 
         elif url is not None:
             self.url = url
-
-        return self
 
     def assert_equal_to(self, other):
         """Assert that the request object is equal to another object.

--- a/src/h_matchers/matcher/web/url/fluent.py
+++ b/src/h_matchers/matcher/web/url/fluent.py
@@ -64,12 +64,9 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no scheme.
 
         :param scheme: None, string or matcher for the scheme
-        :return: self for fluent chaining
         """
 
         self.parts["scheme"] = self._apply_field_default("scheme", scheme)
-
-        return self
 
     @fluent_entrypoint
     def with_host(self, host=AnyURLCore.APPLY_DEFAULT):
@@ -78,11 +75,8 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no host.
 
         :param host: None, string or matcher for the host
-        :return: self for fluent chaining
         """
         self.parts["host"] = self._apply_field_default("host", host)
-
-        return self
 
     @fluent_entrypoint
     def with_path(self, path=AnyURLCore.APPLY_DEFAULT):
@@ -91,7 +85,6 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no path.
 
         :param path: None, string or matcher for the path
-        :return: self for fluent chaining
         """
         if path is AnyURLCore.APPLY_DEFAULT:
             self.parts["path"] = AnyString()
@@ -100,18 +93,13 @@ class AnyURL(AnyURLCore):
                 path, self.parts["scheme"], self.parts["host"]
             )
 
-        return self
-
     @fluent_entrypoint
     def containing_query(self, query):
         """Specify that the query must have at least the items specified.
 
         :param query: A mappable to check
-        :return: self for fluent chaining
         """
         self._set_query(query, exact_match=False)
-
-        return self
 
     @fluent_entrypoint
     def with_query(self, query=AnyURLCore.APPLY_DEFAULT):
@@ -120,12 +108,9 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no query.
 
         :param query: None, mapping or matcher for the query
-        :return: self for fluent chaining
         """
         query = self._apply_field_default("query", query)
         self._set_query(query)
-
-        return self
 
     @fluent_entrypoint
     def with_fragment(self, fragment=AnyURLCore.APPLY_DEFAULT):
@@ -134,8 +119,5 @@ class AnyURL(AnyURLCore):
         If you pass None this will ensure the URL has no fragment.
 
         :param fragment: None, string or matcher for the fragment
-        :return: self for fluent chaining
         """
         self.parts["fragment"] = self._apply_field_default("fragment", fragment)
-
-        return self


### PR DESCRIPTION
The compact with fluent entrypoint is that you can call it as either a class, or instance method and it always ends up as an instance method.

It also expects you return `self` to make the fluent part work. This is busy work we can do for you in the decorator to cut out some repeated nonsense.

Honestly this is mostly because it was annoying me to write `return self` and the same doc string over and over. This also prevents us from forgetting to do it.