### PR TITLE
Split the README into multiple pages and add Any.request() docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,173 +29,29 @@ assert "http://www.example.com?a=3&b=2" == Any.url(
 assert 5 == Any.of([5, None])
 
 assert "foo bar" == All.of([
-    AnyString.containing('foo'), 
-    AnyString.containing('bar')
+    Any.string.containing('foo'),
+    Any.string.containing('bar')
 ])
+
+assert user == Any.object.of_type(MyUser).with_attrs({"name": "Username"})
+
+assert "http://example.com/path" == Any.url.with_host("example.com")
+
+assert prepared_request == (
+    Any.request
+    .with_url(Any.url.with_host("example.com"))
+    .containing_headers({'Content-Type': 'application/json'})
+)
+
+# ... and lots more
 ```
 
-### Comparing to collections
-You can make basic comparisons to collections as follows:
+For more details see:
 
-```python
-Any.iterable()
-Any.list()
-Any.set()
-```
-
-You can specify a custom class with:
-
-```python
-Any.iterable.of_type(MyCustomList)
-```
-
-#### Specifying size
-
-You can also chain on to add requirements for the size.
-
-```python
-Any.iterable.of_size(4)
-Any.list.of_size(at_least=3)
-Any.set.of_size(at_most=5)
-Any.set.of_size(at_least=3, at_most=5)
-```
-
-#### Specifying specific content
-
-You can require an iterable to have a minimum number of items, with repetitions
-, optionally in order:
-
-```python
-Any.iterable.containing([1])
-Any.list.containing([1, 2, 2])
-Any.list.containing([1, 2, 2]).in_order()
-```
-
-This will match if the sequence is found any where in the iterable.
-
-You can also say that there cannot be any extra items in the iterable:
-
-```python
-Any.set.containing({2, 3, 4}).only()
-Any.list.containing([1, 2, 2, 3]).only().in_order()
-```
-
-All of this should work with non-hashable items too as long as the items test
-as equal:
-
-```python
-Any.set.containing([{'a': 1}, {'b': 2}])
-```
-
-#### Specifying every item must match something
-
-You can specify that every item in the collection must match a certain item.
-You can also pass matchers to this:
-
-```python
-Any.list.comprised_of(Any.string).of_size(6)
-Any.iterable.comprised_of(True)
-```
-
-### Comparing to dicts
-
-Basic comparisons are available:
-
-```python
-Any.iterable()
-Any.mapping()
-Any.dict()
-```
-
-### Most things for collections go for dicts too
-
-```python
-Any.dict.of_size(at_most=4)
-Any.dict.containing(['key_1', 'key_2']).only()
-```
-
-### You can test for key value pairs
-
-```python
-Any.dict.containing({'a': 5, 'b': 6})
-Any.dict.containing({'a': 5, 'b': 6}).only()
-```
-
-### You can compare against any mappable including multi-value dicts
-
-This is useful for dict-like objects which may have different behavior and
-semantics to regular dicts. For example: objects which support multiple values
-for the same key.
-
-```python
-Any.mapping.containing(MultiDict(['a', 1], ['a', 2]))
-```
-
-### Comparing with simple objects
-
-```python
-Any.object.of_type(User).with_attrs({"username": "name", "id": 4})
-Any.object(User, {"username": "name", "id": 4})
-```
-
-### Comparing to URLs
-
-The URL matcher provides a both a kwargs interface and a fluent style interface which is a little
-more verbose but provides more readable results.
-
-You can construct matchers directly from URLs:
-
-```python
-Any.url("http://example.com/path?a=b#anchor")
-Any.url.matching("http://example.com/path?a=b#anchor")
-```
-
-You can also construct URL matchers manually:
-
-```python
-Any.url(host='www.example.com', path='/path')
-Any.url.matching('www.example.com').with_path('/path')
-
-Any.url(scheme=Any.string.containing('http'), query={'a': 'b'}, fragment='anchor')
-Any.url.with_scheme(Any.string.containing('http')).with_query({'a': 'b'}).with_fragment('anchor')
-```
-
-Or mix and match, here the separate `host=Any()` argument overrides the `example.com` in the URL and allows URLs with any host to match:
-```python
-Any.url("http://example.com/path?a=b#anchor", host=Any())  
-Any.url.matching("http://example.com/path?a=b#anchor").with_host(Any()) 
-```
-
-#### Matching URL queries
-
-You can specify the query in a number of different ways:
-
-```python
-Any.url(query='a=1&a=2&b=2')
-Any.url.with_query('a=1&a=2&b=2')
-
-Any.url(query={'a': '1', 'b': '2'})
-Any.url.with_query({'a': '1', 'b': '2'})
-
-Any.url(query=[('a', '1'), ('a', '2'), ('b', '2')])
-Any.url.with_query([('a', '1'), ('a', '2'), ('b', '2')])
-
-Any.url(query=Any.mapping.containing({'a': '1'}))
-Any.url.containing_query({'a': '1'})
-```
-
-#### Specify that a component must be present
-
-With the fluent interface you can specify that a URL must contain a certain 
-part without specifying what that part has to be:
-
-```python
-AnyURL.with_scheme()
-AnyURL.with_host()
-AnyURL.with_path()
-AnyURL.with_query()
-AnyURL.with_fragment()
-```
+* [Matching data structures](docs/matching-data-structures.md) - For details
+  of matching collections and objects
+* [Matching web objects](docs/matching-web.md) - For details about matching
+  URLs, and web requests
 
 Hacking
 -------

--- a/docs/matching-data-structures.md
+++ b/docs/matching-data-structures.md
@@ -1,0 +1,105 @@
+# Matching data structures
+
+## Comparing with simple objects
+
+```python
+Any.object.of_type(User).with_attrs({"username": "name", "id": 4})
+Any.object(User, {"username": "name", "id": 4})
+```
+
+## Comparing to collections
+You can make basic comparisons to collections as follows:
+
+```python
+Any.iterable()
+Any.list()
+Any.set()
+```
+
+You can specify a custom class with:
+
+```python
+Any.iterable.of_type(MyCustomList)
+```
+
+#### Specifying size
+
+You can also chain on to add requirements for the size.
+
+```python
+Any.iterable.of_size(4)
+Any.list.of_size(at_least=3)
+Any.set.of_size(at_most=5)
+Any.set.of_size(at_least=3, at_most=5)
+```
+
+#### Specifying specific content
+
+You can require an iterable to have a minimum number of items, with repetitions
+, optionally in order:
+
+```python
+Any.iterable.containing([1])
+Any.list.containing([1, 2, 2])
+Any.list.containing([1, 2, 2]).in_order()
+```
+
+This will match if the sequence is found any where in the iterable.
+
+You can also say that there cannot be any extra items in the iterable:
+
+```python
+Any.set.containing({2, 3, 4}).only()
+Any.list.containing([1, 2, 2, 3]).only().in_order()
+```
+
+All of this should work with non-hashable items too as long as the items test
+as equal:
+
+```python
+Any.set.containing([{'a': 1}, {'b': 2}])
+```
+
+#### Specifying every item must match something
+
+You can specify that every item in the collection must match a certain item.
+You can also pass matchers to this:
+
+```python
+Any.list.comprised_of(Any.string).of_size(6)
+Any.iterable.comprised_of(True)
+```
+
+## Comparing to dicts
+
+Basic comparisons are available:
+
+```python
+Any.iterable()
+Any.mapping()
+Any.dict()
+```
+
+### Most things for collections go for dicts too
+
+```python
+Any.dict.of_size(at_most=4)
+Any.dict.containing(['key_1', 'key_2']).only()
+```
+
+### You can test for key value pairs
+
+```python
+Any.dict.containing({'a': 5, 'b': 6})
+Any.dict.containing({'a': 5, 'b': 6}).only()
+```
+
+### You can compare against any mappable including multi-value dicts
+
+This is useful for dict-like objects which may have different behavior and
+semantics to regular dicts. For example: objects which support multiple values
+for the same key.
+
+```python
+Any.mapping.containing(MultiDict(['a', 1], ['a', 2]))
+```

--- a/docs/matching-web.md
+++ b/docs/matching-web.md
@@ -58,3 +58,72 @@ AnyURL.with_path()
 AnyURL.with_query()
 AnyURL.with_fragment()
 ```
+
+## Matching request objects
+
+The request matcher will match a number of request objects from different
+libraries with a common interface. For details see:
+[h_matchers.matcher.web.request](../src/h_matchers/matcher/web/request.py).
+
+This allows you to make assertions about objects like `requests.Request`:
+
+```python
+Any.request()
+
+Any.request(url="http://example.com")
+Any.request.with_url("http://example.com")
+
+Any.request(method="GET")
+Any.request.with_method("GET")
+
+Any.request(headers={"Content-Type": "application/json"})
+Any.request.with_headers({"Content-Type": "application/json"})
+
+Any.request.containing_headers({"Content-Type": "application/json"})
+```
+
+### Header matching takes exact rows
+
+At the moment even though two sets of headers might be equivalent:
+
+```
+Cache-Control: max-age=0
+Cache-Control: no-cache
+
+# vs.
+
+Cache-Control: max-age=0; no-cache
+```
+
+We currently only match exact row values. No parsing of the header values is
+performed.
+
+### You can use any of these in combination
+
+```python
+Any.request(
+    method="GET",
+    url="http://example.com",
+    headers={
+        "Content-Type": "application/json"
+    }
+)
+
+Any.request("GET", "http://example.com", {
+    "Content-Type": "application/json"
+})
+
+Any.request.with_method("GET").with_url("http://example.com").with_headers({
+    "Content-Type": "application/json"
+})
+```
+
+### All methods accept other matchers as options
+
+```python
+Any.request(
+    method=Any.of(["POST", "PATCH"]),
+    url=Any.url.with_scheme("https"),
+    headers=Any.mapping.of_size(at_least=3)
+)
+```

--- a/docs/matching-web.md
+++ b/docs/matching-web.md
@@ -1,0 +1,60 @@
+# Matching web objects
+
+## Comparing to URLs
+
+The URL matcher provides a both a kwargs interface and a fluent style interface which is a little
+more verbose but provides more readable results.
+
+You can construct matchers directly from URLs:
+
+```python
+Any.url("http://example.com/path?a=b#anchor")
+Any.url.matching("http://example.com/path?a=b#anchor")
+```
+
+You can also construct URL matchers manually:
+
+```python
+Any.url(host='www.example.com', path='/path')
+Any.url.matching('www.example.com').with_path('/path')
+
+Any.url(scheme=Any.string.containing('http'), query={'a': 'b'}, fragment='anchor')
+Any.url.with_scheme(Any.string.containing('http')).with_query({'a': 'b'}).with_fragment('anchor')
+```
+
+Or mix and match, here the separate `host=Any()` argument overrides the `example.com` in the URL and allows URLs with any host to match:
+```python
+Any.url("http://example.com/path?a=b#anchor", host=Any())  
+Any.url.matching("http://example.com/path?a=b#anchor").with_host(Any()) 
+```
+
+#### Matching URL queries
+
+You can specify the query in a number of different ways:
+
+```python
+Any.url(query='a=1&a=2&b=2')
+Any.url.with_query('a=1&a=2&b=2')
+
+Any.url(query={'a': '1', 'b': '2'})
+Any.url.with_query({'a': '1', 'b': '2'})
+
+Any.url(query=[('a', '1'), ('a', '2'), ('b', '2')])
+Any.url.with_query([('a', '1'), ('a', '2'), ('b', '2')])
+
+Any.url(query=Any.mapping.containing({'a': '1'}))
+Any.url.containing_query({'a': '1'})
+```
+
+#### Specify that a component must be present
+
+With the fluent interface you can specify that a URL must contain a certain 
+part without specifying what that part has to be:
+
+```python
+AnyURL.with_scheme()
+AnyURL.with_host()
+AnyURL.with_path()
+AnyURL.with_query()
+AnyURL.with_fragment()
+```


### PR DESCRIPTION
The README was getting very lanky. We've just been adding to it over time, but the library does too much to just have one long rambing page.

## Review notes

* It's easiest to review in context: https://github.com/hypothesis/h-matchers/tree/split-readme
* The first change just moved what was already there + adding some new examples to the main page