### PR TITLE
Add asserting instead of equality for URLs

### DIFF
--- a/src/h_matchers/matcher/core.py
+++ b/src/h_matchers/matcher/core.py
@@ -14,6 +14,12 @@ class Matcher:
     other.
     """
 
+    # Enable failing on comparison instead of returning False. This can be very
+    # useful for debugging as we can fail fast and return a message about why
+    # we can't match. We might want to think about making this a more general
+    # feature. It is up to individual matchers to support it
+    assert_on_comparison = False
+
     def __init__(self, description, test_function):
         self._description = description
         self._test_function = test_function

--- a/src/h_matchers/matcher/core.py
+++ b/src/h_matchers/matcher/core.py
@@ -14,7 +14,7 @@ class Matcher:
     other.
     """
 
-    # Enable failing on comparison instead of returning False. This can be very
+    # Enable raising on comparison instead of returning False. This can be very
     # useful for debugging as we can fail fast and return a message about why
     # we can't match. We might want to think about making this a more general
     # feature. It is up to individual matchers to support it

--- a/src/h_matchers/matcher/web/request.py
+++ b/src/h_matchers/matcher/web/request.py
@@ -54,12 +54,6 @@ class AnyRequest(Matcher):  # pragma: no cover
         {RequestsRequest, RequestsPreparedRequest, PyramidRequest, PyramidDummyRequest}
     )
 
-    # Enable failing on comparison instead of returning False. This can be very
-    # useful for debugging as we can fail fast and return a message about why
-    # we can't match. We might want to think about making this a more general
-    # feature. It would be very handy for the more complex matchers
-    _assert_on_comparison = False
-
     method = None
     url = None
     headers = None
@@ -157,8 +151,8 @@ class AnyRequest(Matcher):  # pragma: no cover
         if self.method is not None and self.method != other.method.upper():
             raise AssertionError(f"Method '{other.method}' != '{self.method}'")
 
-        if self.url is not None and self.url != other.url:
-            raise AssertionError(f"URL '{other.url}' != '{self.url}'")
+        if self.url is not None:
+            self.url.assert_equal_to(other.url)
 
         if self.headers is not None:
             other_headers = self._comparison_headers(other)
@@ -179,7 +173,7 @@ class AnyRequest(Matcher):  # pragma: no cover
         try:
             self.assert_equal_to(other)
         except AssertionError:
-            if self._assert_on_comparison:
+            if self.assert_on_comparison:
                 raise
             return False
 

--- a/src/h_matchers/matcher/web/url/core.py
+++ b/src/h_matchers/matcher/web/url/core.py
@@ -248,13 +248,33 @@ class AnyURLCore(Matcher):
 
         return None, path
 
-    def _matches_url(self, other):
+    def assert_equal_to(self, other):
+        """Assert that the URL object is equal to another object.
+
+        :raise AssertionError: If no match is found with details of why
+        """
+
         if not isinstance(other, str):
-            return False
+            raise AssertionError("Other URL is not a string")
 
         comparison = self.parse_url(other)
 
-        return self.parts == comparison
+        for key, self_value in self.parts.items():
+            other_value = comparison.get(key)
+
+            if self_value != other_value:
+                raise AssertionError(f"Other '{key}' {other_value} != {self_value}")
+
+    def _matches_url(self, other):
+        try:
+            self.assert_equal_to(other)
+        except AssertionError:
+            if self.assert_on_comparison:
+                raise
+
+            return False
+
+        return True
 
 
 class MultiValueQuery(list):

--- a/tests/unit/h_matchers/matcher/web/url/core_test.py
+++ b/tests/unit/h_matchers/matcher/web/url/core_test.py
@@ -186,6 +186,15 @@ class TestAnyURL:
         assert "boo" in repr(matcher)
         assert "boo" in str(matcher)
 
+    def test_it_raises_with_assert_on_comparison_enabled(self):
+        # Normally you'd turn this on for the whole class, but it has totally
+        # non-local effects and explodes the tests
+        matcher = AnyURLCore(scheme="missing")
+        matcher.assert_on_comparison = True
+
+        with pytest.raises(AssertionError):
+            _ = "abc" == matcher
+
     def test_stringification_default(self):
         assert str(AnyURLCore()) == "* any URL *"
 


### PR DESCRIPTION
This is to address the issue where a match fails and you have no idea why. This allows you to flip the switch temporarily in your tests and see why it happened.

I think it would be good to make this more widespread, but for the moment it's just request and url.

You can enable it for URLs, or requests (which enables it for URLs too, for that comparison) by doing:

```
Any.url.assert_on_comparison = True
Any.request.assert_on_comparison = True
```

This will get you feedback of the level "The headers didn't match", but it won't tell you why they didn't.