### PR TITLE
Apply matchers on the LHS to give their equals method priority

### DIFF
--- a/src/h_matchers/matcher/collection/_mixin/item_matcher.py
+++ b/src/h_matchers/matcher/collection/_mixin/item_matcher.py
@@ -38,7 +38,7 @@ class ItemMatcherMixin:
         items = original.keys() if isinstance(original, dict) else other
 
         for item in items:
-            if not item == self._item_matcher:
+            if not self._item_matcher == item:
                 raise NoMatch("Item does not match item matcher")
 
     def _describe_item_matcher(self):

--- a/src/h_matchers/matcher/combination.py
+++ b/src/h_matchers/matcher/combination.py
@@ -24,7 +24,7 @@ class AllOf(Matcher):
 
         super().__init__(
             f"* all of {options} *",
-            lambda other: all(other == option for option in options),
+            lambda other: all(option == other for option in options),
         )
 
 

--- a/tests/unit/h_matchers/matcher/collection/_mixin/item_matcher_test.py
+++ b/tests/unit/h_matchers/matcher/collection/_mixin/item_matcher_test.py
@@ -23,3 +23,12 @@ class TestItemMatcherMixin:
 
         assert matcher != ["a", "b", 1]
         assert matcher != {"a": 1, "b": 1, 3: None}
+
+    def test_it_can_match_objects_with_equals(self):
+        class NeverMatches:
+            def __eq__(self, other):  # pragma: no cover
+                return False
+
+        matcher = HostClass.comprised_of(Any.instance_of(NeverMatches))
+
+        assert matcher == [NeverMatches()]

--- a/tests/unit/h_matchers/matcher/combination_test.py
+++ b/tests/unit/h_matchers/matcher/combination_test.py
@@ -1,3 +1,4 @@
+from h_matchers.matcher.anything import AnyThing
 from h_matchers.matcher.collection import AnyMapping
 from h_matchers.matcher.combination import AllOf, AnyOf, NamedMatcher
 from h_matchers.matcher.strings import AnyString
@@ -43,6 +44,15 @@ class TestAllOf:
         assert matcher == 1
         assert matcher == 1
         assert matcher != 10
+
+    def test_it_can_match_objects_with_equals(self):
+        class NeverMatches:
+            def __eq__(self, other):  # pragma: no cover
+                return False
+
+        matcher = AllOf([AnyThing()])
+
+        assert matcher == NeverMatches()
 
 
 class TestNamedMatcher:


### PR DESCRIPTION
When trying to compare certain items with their own equals method this would previously have called the compared object's method, rather than the matcher.

This allows us to match un-cooperative objects.

This came up during testing when trying to compare to an SQLAlchemy `BinaryExpression` object, which has it's own equality method.

## What does this fix?

If we have an object with it's own equals method which doesn't return true then the following statements would fail before:

```
assert [NeverMatches()] == Any.list.comprised_of(Any())
assert NeverMatches() == AllOf([Any()]))
```

Both of these should logically work