### PR TITLE
Integrate assertion behavior into the code matcher

### DIFF
--- a/src/h_matchers/matcher/core.py
+++ b/src/h_matchers/matcher/core.py
@@ -25,7 +25,12 @@ class Matcher:
         self._test_function = test_function
 
     def __eq__(self, other):
-        return self._test_function(other)
+        try:
+            return self._test_function(other)
+        except AssertionError:
+            if self.assert_on_comparison:
+                raise
+            return False
 
     def __str__(self):
         return self._description  # pragma: no cover

--- a/src/h_matchers/matcher/web/request.py
+++ b/src/h_matchers/matcher/web/request.py
@@ -63,7 +63,7 @@ class AnyRequest(Matcher):  # pragma: no cover
         self.with_url(url)
         self.with_headers(headers)
 
-        super().__init__("*dummy*", self._matches_request)
+        super().__init__("*dummy*", self.assert_equal_to)
 
     @classmethod
     def containing_headers(cls, headers):
@@ -141,6 +141,7 @@ class AnyRequest(Matcher):  # pragma: no cover
         """Assert that the request object is equal to another object.
 
         :raise AssertionError: If no match is found with details of why
+        :return: True if equal
         """
         if not isinstance(other, self.SUPPORTED_TYPES):
             raise AssertionError(
@@ -159,6 +160,8 @@ class AnyRequest(Matcher):  # pragma: no cover
             if self.headers != other_headers:
                 raise AssertionError(f"Headers {other_headers} != {self.headers}")
 
+        return True
+
     @classmethod
     def _comparison_headers(cls, other):
         if isinstance(other, PyramidRequest):
@@ -168,16 +171,6 @@ class AnyRequest(Matcher):  # pragma: no cover
             return headers
 
         return other.headers
-
-    def _matches_request(self, other):
-        try:
-            self.assert_equal_to(other)
-        except AssertionError:
-            if self.assert_on_comparison:
-                raise
-            return False
-
-        return True
 
     def __str__(self):
         details = ""

--- a/src/h_matchers/matcher/web/url/core.py
+++ b/src/h_matchers/matcher/web/url/core.py
@@ -127,7 +127,7 @@ class AnyURLCore(Matcher):
             # Apply default matchers for everything not provided
             self._apply_defaults(self.parts, self.DEFAULTS)
 
-        super().__init__("dummy", self._matches_url)
+        super().__init__("dummy", self.assert_equal_to)
 
     def __str__(self):
         contraints = {
@@ -257,6 +257,7 @@ class AnyURLCore(Matcher):
         """Assert that the URL object is equal to another object.
 
         :raise AssertionError: If no match is found with details of why
+        :return: True if equal
         """
 
         if not isinstance(other, str):
@@ -269,15 +270,6 @@ class AnyURLCore(Matcher):
 
             if self_value != other_value:
                 raise AssertionError(f"Other '{key}' {other_value} != {self_value}")
-
-    def _matches_url(self, other):
-        try:
-            self.assert_equal_to(other)
-        except AssertionError:
-            if self.assert_on_comparison:
-                raise
-
-            return False
 
         return True
 

--- a/tests/unit/h_matchers/matcher/core_test.py
+++ b/tests/unit/h_matchers/matcher/core_test.py
@@ -26,6 +26,24 @@ class TestMatcher:
         assert Matcher(sentinel.description, no_way) != sentinel.other
         no_way.assert_called_once_with(sentinel.other)
 
+    def test_it_compares_as_not_equal_for_AssertionError(self, raise_assertion_error):
+        assert Matcher(sentinel.description, raise_assertion_error) != sentinel.other
+        raise_assertion_error.assert_called_once_with(sentinel.other)
+
+    def test_it_compares_at_not_equal_if_assert_on_comparison(
+        self, raise_assertion_error
+    ):
+        matcher = Matcher(sentinel.description, raise_assertion_error)
+        matcher.assert_on_comparison = True
+
+        with pytest.raises(AssertionError):
+            matcher.__eq__(sentinel.other)
+
+    @pytest.fixture
+    def raise_assertion_error(self, function):
+        function.side_effect = AssertionError
+        return function
+
     @pytest.fixture
     def true_dat(self, function):
         function.return_value = True

--- a/tests/unit/h_matchers/matcher/web/url/core_test.py
+++ b/tests/unit/h_matchers/matcher/web/url/core_test.py
@@ -13,7 +13,7 @@ class TestAnyURL:
         matcher = AnyURLCore()
 
         assert "" == matcher
-        assert None != matcher
+        assert 3 != matcher
 
     BASE_URL = "http://www.example.com/path;params?a=1&b=2#fragment"
 
@@ -200,6 +200,10 @@ class TestAnyURL:
 
         with pytest.raises(AssertionError):
             _ = "abc" == matcher
+
+    @pytest.mark.parametrize("other", (None, 123, True))
+    def test_it_refuses_to_compare_to_non_strings(self, other):
+        assert AnyURLCore() != other
 
     def test_stringification_default(self):
         assert str(AnyURLCore()) == "* any URL *"


### PR DESCRIPTION
This means that any matcher that raises assertion errors will automatically work with `assert_on_comparison`. This is actually
a result of fancy new linting in Python 3.9 and is mostly here to unblock linting when implementing Python 3.9 support.

This also fixes various other linting issues.