### PR TITLE
Replay the cookiecutter templates over the project

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,6 +3,7 @@ on: [push]
 
 jobs:
   metadata:
+    name: Metadata
     runs-on: ubuntu-latest
     outputs:
       python_versions: ${{ steps.list-python-versions.outputs.python_versions }}
@@ -25,6 +26,7 @@ jobs:
         echo "::set-output name=python_headline_version::`hdev python_version --style plain --first`"
 
   lint:
+    name: Lint
     needs: metadata
     runs-on: ubuntu-latest
     steps:
@@ -53,15 +55,14 @@ jobs:
         pip install pylint
         pylint --reports=y src bin
         pylint --reports=y --rcfile=tests/.pylintrc tests
-
   test:
+    name: Tests on python ${{ matrix.python-version }}
     needs: metadata
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ${{ fromJSON(needs.metadata.outputs.python_versions) }}
 
-    name: Tests on python ${{ matrix.python-version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -121,7 +122,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ needs.metadata.outputs.python_headline_version }}
 
@@ -150,7 +151,7 @@ jobs:
         name: dist
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ needs.metadata.outputs.python_headline_version }}
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -14,7 +14,6 @@ load-plugins=pylint.extensions.bad_builtin,
 disable=bad-continuation,
         missing-type-doc,
         missing-return-type-doc,
-        wrong-import-order,
 
 [REPORTS]
 output-format=colorized

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "make release           Tag a release and trigger deployment to PyPI"
 	@echo "make initialrelease    Create the first release of a package"
 	@echo "make test              Run the unit tests"
+	@echo "make testall           Run the unit tests against all versions of Python"
 	@echo "make sure              Make sure that the formatter, linter, tests, etc all pass"
 	@echo "make coverage          Print the unit test coverage report"
 	@echo "make clean             Delete development artefacts (cached files, "

--- a/bin/install-python.sh
+++ b/bin/install-python.sh
@@ -15,6 +15,15 @@
 #
 # $ ./bin/install-python.sh
 
+# Exit if we're running on GitHub Actions.
+# On GitHub Actions we just want to use the versions of Python provided in the
+# GitHub Actions VM, even though they may not have be the same patch versions
+# as in .python-version.
+if [ "$GITHUB_ACTIONS" = "true" ]
+then
+  exit
+fi
+
 # Exit if we're running on Travis CI.
 # On Travis we just want to use the versions of Python provided in the Travis
 # VM, even though they may not have be the same patch versions as in

--- a/bin/next_version.py
+++ b/bin/next_version.py
@@ -1,10 +1,9 @@
 """Suggest a new tag to make a release with."""
 
-from distutils.errors import DistutilsFileError
+from configparser import ConfigParser
 from subprocess import check_output
 
 from packaging import version
-from setuptools.config import read_configuration
 
 
 class VersionSuggester:
@@ -24,10 +23,10 @@ class VersionSuggester:
     @classmethod
     def major_minor_version(cls):
         """Find the major minor declared in the setup.cfg."""
-        try:
-            config = read_configuration("setup.cfg")
-        except DistutilsFileError:
-            raise FileNotFoundError("setup.cfg") from None
+
+        config = ConfigParser()
+        if not config.read("setup.cfg"):
+            raise FileNotFoundError("setup.cfg")
 
         return version.parse(config["metadata"]["version"])
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,3 @@
 filterwarnings =
     # Fail the tests if there are any warnings.
     error
-
-    # Silence an imp warning that pyramid path causes
-    ignore:^the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses$:DeprecationWarning:.*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
+from configparser import ConfigParser
 
 from setuptools import find_packages, setup
-from setuptools.config import read_configuration
 
 
 class Package:
@@ -68,7 +68,9 @@ class Package:
 
             start = "v" + self.version + "."
             if not build.startswith(start):
-                raise ValueError(f'Expected build to be "{start}*", got "{build}"')
+                raise ValueError(
+                    'Expected build to be "{}*", got "{}"'.format(start, build)
+                )
 
             return self.version + "." + build[len(start) :]
 
@@ -87,7 +89,9 @@ class Package:
         return self.version + ".dev0"
 
 
-package = Package(read_configuration("setup.cfg"))
+config = ConfigParser()
+config.read("setup.cfg")
+package = Package(config)
 
 setup(
     # Metadata

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -21,7 +21,6 @@ disable=bad-continuation,
         no-self-use,
         redefined-outer-name,
         too-few-public-methods,
-        wrong-import-order,
 
 [REPORTS]
 output-format=colorized


### PR DESCRIPTION
Replaying the exported multi-python support back over `h-matchers`. If this works ok, we should be able to replay this into other libraries to add support.

## Testing notes

This is a result of running `make template`. So running `make template` again should result in no changes.

Other than that the various commands should work (like `make test`, `make sure`, `make testall` etc.) and CI should pass (which it currently is).