### PR TITLE
Add assertion capabilities to the object matcher

### DIFF
--- a/src/h_matchers/matcher/object.py
+++ b/src/h_matchers/matcher/object.py
@@ -33,7 +33,7 @@ class AnyObject(Matcher):  # pragma: no cover
         self.__type = type_
         self.__attributes = attributes
 
-        super().__init__("dummy", self._matches_object)
+        super().__init__("dummy", self.assert_equal_to)
 
     @staticmethod
     def of_type(type_):
@@ -73,17 +73,28 @@ class AnyObject(Matcher):  # pragma: no cover
 
         self.__attributes = attributes
 
-    def _matches_object(self, other):
+    def assert_equal_to(self, other):
+        """Assert that the object is equal to another object.
+
+        :raise AssertionError: If no match is found with details of why
+        :return: True if equal
+        """
+
         if self.__type is not None and not isinstance(other, self.__type):
-            return False
+            raise AssertionError(
+                f"Expected other object to be of type '{self.__type}', found: '{type(other)}'"
+            )
 
         if self.__attributes is not None:
             for key, value in self.__attributes.items():
                 if not hasattr(other, key):
-                    return False
+                    raise AssertionError(f"Expected attribute '{key}' on {other}")
 
-                if getattr(other, key) != value:
-                    return False
+                other_value = getattr(other, key)
+                if other_value != value:
+                    raise AssertionError(
+                        f"Expected attribute '{key}' == '{value}', found: '{other_value}"
+                    )
 
         return True
 

--- a/tests/unit/h_matchers/matcher/object_test.py
+++ b/tests/unit/h_matchers/matcher/object_test.py
@@ -26,10 +26,15 @@ class TestAnyObject:
         ),
     )
     def test_it_matches_types_correctly(self, type_, instance, matches):
+        matcher = AnyObject(type_=type_)
+
         if matches:
-            assert instance == AnyObject(type_=type_)
+            assert instance == matcher
+            assert matcher.assert_equal_to(instance)
         else:
-            assert instance != AnyObject(type_=type_)
+            assert instance != matcher
+            with pytest.raises(AssertionError):
+                matcher.assert_equal_to(instance)
 
     @pytest.mark.parametrize(
         "attributes,matches",
@@ -44,11 +49,15 @@ class TestAnyObject:
     )
     def test_it_matches_with_attributes_correctly(self, attributes, matches):
         other = ValueObject(one="one", two="two")
+        matcher = AnyObject.with_attrs(attributes)
 
         if matches:
-            assert other == AnyObject.with_attrs(attributes)
+            assert other == matcher
+            assert matcher.assert_equal_to(other)
         else:
-            assert other != AnyObject.with_attrs(attributes)
+            assert other != matcher
+            with pytest.raises(AssertionError):
+                matcher.assert_equal_to(other)
 
     @pytest.mark.parametrize("bad_input", (None, 1, []))
     def test_it_raise_ValueError_if_attributes_does_not_support_items(self, bad_input):


### PR DESCRIPTION
For: https://github.com/hypothesis/h-matchers/issues/44

This allows you to either do:

```Any.object.assert_equal_to(...)```

Or to add:

```Any.assert_on_comparison = True```

to debug failing tests.