### PR TITLE
Add capturing of last matched object

### DIFF
--- a/src/h_matchers/matcher/collection/__init__.py
+++ b/src/h_matchers/matcher/collection/__init__.py
@@ -18,14 +18,13 @@ class AnyCollection(
     def __init__(self):
         # Pass None as our function, as we will be in charge of our own type
         # checking
-        super().__init__("dummy", None)
+        super().__init__("dummy", self.assert_equal_to)
 
-    def __eq__(self, other):
+    def assert_equal_to(self, other):
         try:
             copy = list(other)
-        except TypeError:
-            # Not iterable
-            return False
+        except TypeError as err:
+            raise AssertionError("Object is not iterable") from err
 
         # Execute checks roughly in complexity order
         for checker in [
@@ -36,8 +35,8 @@ class AnyCollection(
         ]:
             try:
                 checker(copy, original=other)
-            except NoMatch:
-                return False
+            except NoMatch as err:
+                raise AssertionError("No match could be found") from err
 
         return True
 
@@ -87,8 +86,7 @@ class AnyGenerator(AnyCollection):
 class AnyMapping(AnyCollection):
     """A matcher representing any mapping."""
 
-    def __eq__(self, other):
-        if not hasattr(other, "items"):
-            return False
+    def assert_equal_to(self, other):
+        assert hasattr(other, "items"), "Mapping object needs items()"
 
-        return super().__eq__(other)
+        return super().assert_equal_to(other)

--- a/src/h_matchers/matcher/core.py
+++ b/src/h_matchers/matcher/core.py
@@ -14,23 +14,48 @@ class Matcher:
     other.
     """
 
-    # Enable raising on comparison instead of returning False. This can be very
-    # useful for debugging as we can fail fast and return a message about why
-    # we can't match. We might want to think about making this a more general
-    # feature. It is up to individual matchers to support it
     assert_on_comparison = False
+    """
+    Enable raising on comparison instead of returning False.
+
+    This can be very useful for debugging as we can fail fast and return a
+    message about why we can't match. We might want to think about making this
+    a more general feature. It is up to individual matchers to support it.
+    """
+
+    matched_to: list
+    """A list of all matched objects."""
 
     def __init__(self, description, test_function):
         self._description = description
         self._test_function = test_function
+        self.reset()
 
     def __eq__(self, other):
         try:
-            return self._test_function(other)
+            matches = self._test_function(other)
         except AssertionError:
             if self.assert_on_comparison:
                 raise
-            return False
+            matches = False
+
+        if matches:
+            self.matched_to.append(other)
+
+        return matches
+
+    def last_matched(self, default=None):
+        """Get the last matched object, if any.
+
+        :param default: Default to return on no match. This can be used to
+            distinguish between not matching and matching None.
+        """
+        return self.matched_to[-1] if self.matched_to else default
+
+    def reset(self):
+        """Clear any stored data (like `last_matched`)."""
+
+        self.matched_to = []
 
     def __str__(self):
         return self._description  # pragma: no cover

--- a/tests/unit/h_matchers/matcher/core_test.py
+++ b/tests/unit/h_matchers/matcher/core_test.py
@@ -39,6 +39,20 @@ class TestMatcher:
         with pytest.raises(AssertionError):
             matcher.__eq__(sentinel.other)
 
+    def test_it_grabs_last_matched(self, function):
+        function.side_effect = (True, False)
+        matcher = Matcher(sentinel.description, function)
+
+        assert matcher.last_matched(None) is None
+        assert matcher.last_matched(...) is ...
+        assert not matcher.matched_to
+
+        assert matcher == "match"
+        assert matcher != "not_match"
+
+        assert matcher.last_matched() == "match"
+        assert matcher.matched_to == ["match"]
+
     @pytest.fixture
     def raise_assertion_error(self, function):
         function.side_effect = AssertionError


### PR DESCRIPTION
This PR adds the ability to capture the last item which was matched by any matcher.

### Why?

Often we use our matchers as part of assertions like:

```python
service.get_items.assert_called_once_with(
    Any.dict.containing({
        "item_def": {
            "url": All.of([
                Any.of([
                    Any.url.with_schema('ftp'),
                    Any.url.with_schema('https').with_query("a=1")
                ]),
                Any.url.with_path('/path')
            ]),
            "start": True, 
            "truncating": False
        }
    })
)
```

Any assertions we want to make about the URL have to be made inline. This can:

 * Make assertions quite big
 * Make it less clear when only one part failed why the whole thing did

### How does this help?

Now we can create a matcher and then interrogate it for how it matched:

```python
url_matcher = Any.url()
service.get_items.assert_called_once_with(
    Any.dict.containing({
       "item_def": {"url": url_matcher, "start": True, "truncating": False}
    })
)

# If we get this far we know the basic structure is correct, and we can
# make as many fine grained assertions as we want to. If the test fails
# from here it'll be more obvious it's about the URL

url = url_matcher.last_match()
assert url == Any.url.with_path("/path")

if url.startswith("https:"):
    assert url == Any.url.with_query("a=1")
elif url.startswith("ftp"):
    ...
# ... or whatever you get the idea

print(url_matcher.matches)    # ["some_url"]
```

This gives us more freedom and control how we express our assertions for max info. It could also be very useful with calls like `assert_has_call` as we could tell what we matched.

### Other use cases

It might be handy when making assertions about deeply nested dicts:

```python
# Make assertions about the large scale structure
return_item = Any.dict()
assert api_return == {
    "_meta": {"success": True},
    "_body": {"_head": {"items": [return_item]]}, "_item_count": 1}
}

# Now separately talk about the nested item
assert return_item.last_match() ...
```

This also lets you do some pretty hairy stuff with the state as we match:

```python
string_matcher = Any.string()
string_len = Matcher("string_len", lambda other: other == len(string_matcher.last_match('')))

assert ["hey", 3] == [string_matcher, string_len]
assert ["hello", 5] == [string_matcher, string_len]
assert ["hello", 10] != [string_matcher, string_len]
```

I think due to the unpredictable order things get compared in within our more complex matchers, this might not be a good idea. It won't work correctly in `Any.list.containing(...)` for example.