### PR TITLE
Fix `make lint`

### DIFF
--- a/src/h_matchers/matcher/number.py
+++ b/src/h_matchers/matcher/number.py
@@ -18,7 +18,6 @@ class AnyNumber(Matcher):
 
     def assert_equal_to(self, other):
         # Ints are also booleans
-        # pylint: disable=compare-to-zero
         assert other is not True and other is not False, "Not a boolean"
 
         # Check it's the right type


### PR DESCRIPTION
Looks like a pylint release must have broken this? It's failing on `main` anyway.
