### PR TITLE
Un-ordered containment matching with more sane matching history

### DIFF
--- a/src/h_matchers/matcher/collection/containment.md
+++ b/src/h_matchers/matcher/collection/containment.md
@@ -1,0 +1,78 @@
+# Matching items in any order
+
+This method uses a constraint satisfaction algorithm to match items
+together, or to prove they can't be matched. The idea is to work out
+all the possible things each item could match against, and then 
+whittle down the possibilities until a solution is found or all options
+have been explored.
+
+## The setup - creating a constraint set
+
+Let's say we have the following container, and a matching target to try
+and find a match for:
+
+    container = [1, "string", 45, None, 45]
+    items_to_match = [45, Any(), Any.int()]
+
+We can take each matching target and list every item it matches:
+
+    45 - {45, 45}
+    Any() - {1, "string", 45, None, 45}
+    Any.int() - {1, 45, 45}
+
+To make storage simpler, object agnostic, and to avoid the confusion about
+the same item at different indexes we cat use the indices of the items instead 
+of their raw values:
+
+    0: {2, 4}
+    1: {0, 1, 2, 3, 4}
+    2: {0, 2, 4}
+
+These are our constraints:
+
+ * Each item on the left must match one of the items on the right
+ * No two items can match the same item
+
+## The search - Finding a solution
+
+The key observation to finding a solution quickly is that items which have
+fewer choices should be chosen first as they have less room for manouver. As
+you search, items with a high degree of freedom are more likely to "work out".
+In the extreme case when there is only one choice there is no search.
+
+To apply this heuristic, we will sort our items by the most constrained first:
+
+    0: {2, 4}
+    2: {0, 2, 4}
+    1: {0, 1, 2, 3, 4}
+    
+We will pick the first item to match (index: 0) and then try each of its 
+possibilities recursively to search for a match. We will only follow one
+branch here where we choose "0 = 2". As we are matching 0 to 2, we know
+nothing else can be, so we will remove it from the other sets:
+
+    0 = 2
+    2: {0, 4}
+    1: {0, 1, 3, 4}
+
+We then, sort again (which results in no change in this case) and go again
+and pick the most constrained unresolved item (index: 2). This time we will 
+first try "2 = 0":
+
+    0 = 2
+    2 = 0
+    1: {1, 3, 4}
+
+As we have no conflict, we continue recursing, sorting again (no change)
+and picking the most constrained unresolved item (index: 1). We will pick
+"1 = 1":
+
+    0 = 2
+    2 = 0
+    1 = 1
+
+We have no unresolved items left, and so a solution is found. 
+
+If at any point any set of possibilities becomes zero we have failed one 
+of our conditions (every item must have a match), so we would abort and
+recurse up picking the next available possibility for the item before.

--- a/src/h_matchers/matcher/collection/containment.py
+++ b/src/h_matchers/matcher/collection/containment.py
@@ -53,6 +53,7 @@ class AnyIterableWithItems(Matcher):
 
     @classmethod
     def _contains_in_any_order(cls, container, items_to_match):
+        # See `containment.md` for a description of this algorithm
         try:
             container = list(container)
         except TypeError:

--- a/tests/unit/h_matchers/matcher/collection/containment_test.py
+++ b/tests/unit/h_matchers/matcher/collection/containment_test.py
@@ -140,3 +140,15 @@ class TestAnyIterableWithItems:
 
         assert ["a", "aa", None] != matcher
         assert matcher != ["a", "aa", None]
+
+    def test_it_remaps_matched_items(self):
+        # This matcher will match against loads of things during the initial
+        # constraint generation. We only want to see the final match
+        sub_matcher = Any()
+        matcher = AnyIterableWithItems([sub_matcher])
+
+        assert matcher == [None, 1, "string"]
+
+        # It's not clear our algorithm is deterministic, but hopefully the first
+        # match is the one we'll hit.
+        assert sub_matcher.matched_to == [None]


### PR DESCRIPTION
Un-ordered containment matching starts by comparing each item to every other item which case matchers `matched_to` histories to become a total mess. We can't necessarily fix that in one go, but we can ensure the `last_matched()` value is something sensible. This will remove all previous history as a result.

This PR involves reworking the matching algorithms to track the solution they come up with, in addition to a true/false value telling us if a match was found.

## Why doesn't this happen in other containment matchers?

Matchers only store a `matched_to` if they match. In the case of the ordered matcher, the first item we match is the last item we are matched to, so it just so happens to work out correctly.

In the case of dicts we follow two paths:

 * A faster dict based comparison, which behaves the same as the ordered matcher
 * A slower method based on un-ordered matching, which we fix in this PR

## How is this useful?

By storing their last matched items, matchers have the ability to act as spies when used in other comparisons:

```python
def test_it(self, svc, patched_item):
    svc.blah()
 
    status_code = Any.int()
    patched_item.assert_called_once_with(status="bad", code=status_code)

    if status_code.last_matched() == 404:
        assert ...
    else:
        assert not ...
```

This is good, but in the case of matchers like `Any.list.containing([my_spy])` the history of `my_spy` get's hopelessly scrambled and you can't tell what it's matched. This fixes this use case.

## Limitations

Matchers store a record of all the things they've successfully matched with. The approach taken in this PR is to store the matching item from the solution and reset the history to be only that item. This will wipe out the larger history.

We could tackle preserving the history and appending to it in another PR.

## Testing notes

```python
from h_matchers import Any

first_matcher = Any.int()
second_matcher = Any.int()
assert Any.iterable.containing([first_matcher, second_matcher]) == [1, 2, 3]

print(first_matcher.matched_to, second_matcher.matched_to)
# In main: [1, 2, 3] [1, 2, 3]
# This branch: [1], [2]

print(first_matcher.last_matched(), second_matcher.last_matched())
# In main: 3 3
# This branch: 1 2
```